### PR TITLE
Implement S3 Bucket Suitable for Serving Static Websites on S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Compiled files
+*.tfstate
+*.tfstate.backup
+*.terraform.tfstate*
+# Module directory
+.terraform/
+
+.idea

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Cloud Posse, LLC 
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,53 @@ Terraform Module for Creating S3 backed Websites
 
 * http://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html
 
+## Usage
+
+module "website" {
+  source      = "git::https://github.com/cloudposse/tf_s3_website.git?ref=master"
+  namespace   = "${var.namespace}"
+  stage       = "${var.stage}"
+  name        = "${var.name}"
+  hostname    = "${var.hostname}"
+  dns_zone_id = "${var.dns_zone_id}"
+}
+
+## Variables
+
+|  Name                               |  Default       |  Description                                                                                                    | Required |
+|:------------------------------------|:--------------:|:----------------------------------------------------------------------------------------------------------------|:--------:|
+| `namespace`                         | ``             | Namespace (e.g. `cp` or `cloudposse`)                                                                           | Yes      |
+| `stage`                             | ``             | Stage (e.g. `prod`, `dev`, `staging`)                                                                           | Yes      |
+| `name`                              | ``             | Name  (e.g. `bastion` or `db`)                                                                                  | Yes      |
+| `attributes`                        | `[]`           | Additional attributes (e.g. `policy` or `role`)                                                                 | No       |
+| `tags`                              | `{}`           | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                                              | No       |
+| `delimiter`                         | `-`            | Delimiter to be used between `name`, `namespace`, `stage`, `arguments`, etc.                                    | No       |
+| `hostname`                          | `[]`           | Name of website bucket in `fqdn` format (e.g. `test.example.com`). IMPORTANT! Do not add trailing dot (`.`)     | Yes      |
+| `dns_zone_id`                       | ``             | ID of the hosted zone to contain the record                                                                     | Yes      |
+| `error_document`                    | `404.html`     | An absolute path to the document to return in case of a 4XX error                                               | No       |
+| `index_document`                    | `index.html`   | Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders        | No       |
+| `force_destroy`                     | ``             | Delete all objects from the bucket so that the bucket can be destroyed without error (e.g. `true` or `false`)   | No       |
+| `lifecycle_rule_enabled`            | ``             | Lifecycle rule status (e.g. `true` or `false`)                                                                  | No       |
+| `noncurrent_version_transition_days`| `30`           | Number of days to persist in the standard storage tier before moving to the glacier tier infrequent access tier | No       |
+| `noncurrent_version_expiration_days`| `90`           | Specifies when noncurrent object versions expire                                                                | No       |
+| `cors_allowed_headers`              | `["*"]`        | List of allowed headers                                                                                         | No       |
+| `cors_allowed_methods`              | `["GET"]`      | List of allowed methods (e.g. ` GET, PUT, POST, DELETE, HEAD`)                                                  | No       |
+| `cors_allowed_origins`              | `["*"]`        | List of allowed origins (e.g. ` example.com, test.com`)                                                         | No       |
+| `cors_max_age_seconds`              | `3600`         | Time in seconds that browser can cache the response                                                             | No       |
+| `cors_expose_headers`               | `["ETag"]`     | List of expose header in the response                                                                           | No       |
+| `prefix`                            | ``             | Prefix identifying one or more objects to which the rule applies                                                | No       |
+| `region`                            | ``             | AWS region this bucket should reside in                                                                         | No       |
+| `routing_rules`                     | ``             | A json array containing routing rules describing redirect behavior and when redirects are applied               | No       |
+| `versioning_enabled`                | ``             | State of versioning (e.g. `true` or `false`)                                                                    | No       |
+| `logs_standard_transition_days`     | `30`           | Number of days to persist in the standard storage tier before moving to the glacier tier                        | No       |
+| `logs_glacier_transition_days`      | `60`           | Number of days after which to move the data to the glacier storage tier                                         | No       |
+| `logs_expiration_days`              | `90`           | Number of days after which to expunge the objects                                                               | No       |
+
+
+## Outputs
+
+| Name                           | Description                                                 |
+|:------------------------------ |:------------------------------------------------------------|
+| `hostname`                     | Assigned DNS-record to the DNS-record of website bucket     |
+| `s3_bucket_domain_name`        | DNS-record of website bucket                                |
+| `s3_bucket_name`               | Name of of website bucket                                   |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # tf_s3_website
+
 Terraform Module for Creating S3 backed Websites
+
+## Further Reading
+
+* http://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html
+

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "aws_s3_bucket" "default" {
   website {
     index_document = "${var.index_document}"
     error_document = "${var.error_document}"
+    routing_rules  = "${var.routing_rules}"
   }
 
   cors_rule {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/tf_log_storage.git?ref=0.1.0"
+  source                   = "git::https://github.com/cloudposse/tf_log_storage.git?ref=tags/0.1.0"
   name                     = "${var.name}"
   stage                    = "${var.stage}"
   namespace                = "${var.namespace}"
@@ -84,9 +84,9 @@ data "aws_iam_policy_document" "default" {
 }
 
 module "dns" {
-  source          = "git::https://github.com/cloudposse/tf_vanity?ref=tags/0.2.0"
-  aliases         = "${var.dns_zone_id ? list(var.hostname) : list()}"
-  zone_id         = "${var.dns_zone_id}"
-  target_dns_name = "${aws_s3_bucket.default.bucket_domain_name}"
+  source          = "git::https://github.com/cloudposse/tf_vanity.git?ref=tags/0.2.0"
+  aliases         = "${list(var.hostname)}"
+  parent_zone_id  = "${var.dns_zone_id}"
+  target_dns_name = "${aws_s3_bucket.default.website_domain}"
   target_zone_id  = "${aws_s3_bucket.default.hosted_zone_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/tf_log_storage.git?ref=master"
+  source                   = "git::https://github.com/cloudposse/tf_log_storage.git?ref=0.1.0"
   name                     = "${var.name}"
   stage                    = "${var.stage}"
   namespace                = "${var.namespace}"
   standard_transition_days = "${var.logs_standard_transition_days}"
-  glacier_transition_days  = "${var.logs.glacier_transition_days}"
-  expiration_days          = "${var.logs.expiration_days}"
+  glacier_transition_days  = "${var.logs_glacier_transition_days}"
+  expiration_days          = "${var.logs_expiration_days}"
 }
 
 module "default_label" {
@@ -31,9 +31,8 @@ resource "aws_s3_bucket" "default" {
   }
 
   website {
-    index_document           = "${var.index_document}"
-    error_document           = "${var.error_document}"
-    redirect_all_requests_to = "${var.redirect_all_requests_to}"
+    index_document = "${var.index_document}"
+    error_document = "${var.error_document}"
   }
 
   cors_rule {
@@ -51,17 +50,16 @@ resource "aws_s3_bucket" "default" {
   lifecycle_rule {
     id      = "${module.default_label.id}"
     enabled = "${var.lifecycle_rule_enabled}"
-
-    prefix = "${var.prefix}"
-    tags   = "${module.default_label.tags}"
-
-    noncurrent_version_expiration {
-      days = "${var.noncurrent_version_expiration_days}"
-    }
+    prefix  = "${var.prefix}"
+    tags    = "${module.default_label.tags}"
 
     noncurrent_version_transition {
       days          = "${var.noncurrent_version_transition_days}"
       storage_class = "GLACIER"
+    }
+
+    noncurrent_version_expiration {
+      days = "${var.noncurrent_version_expiration_days}"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,93 @@
+module "logs" {
+  source                   = "git::https://github.com/cloudposse/tf_log_storage.git?ref=master"
+  name                     = "${var.name}"
+  stage                    = "${var.stage}"
+  namespace                = "${var.namespace}"
+  standard_transition_days = "${var.logs_standard_transition_days}"
+  glacier_transition_days  = "${var.logs.glacier_transition_days}"
+  expiration_days          = "${var.logs.expiration_days}"
+}
+
+module "default_label" {
+  source     = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = ["origin"]
+  tags       = "${var.tags}"
+}
+
+resource "aws_s3_bucket" "default" {
+  bucket        = "${var.hostname}"
+  acl           = "public-read"
+  tags          = "${module.default_label.tags}"
+  region        = "${var.region}"
+  force_destroy = "${var.force_destroy}"
+
+  logging {
+    target_bucket = "${module.logs.bucket_id}"
+    target_prefix = "${module.logs.prefix}"
+  }
+
+  website {
+    index_document           = "${var.index_document}"
+    error_document           = "${var.error_document}"
+    redirect_all_requests_to = "${var.redirect_all_requests_to}"
+  }
+
+  cors_rule {
+    allowed_headers = "${var.cors_allowed_headers}"
+    allowed_methods = "${var.cors_allowed_methods}"
+    allowed_origins = "${var.cors_allowed_origins}"
+    expose_headers  = "${var.cors_expose_headers}"
+    max_age_seconds = "${var.cors_max_age_seconds}"
+  }
+
+  versioning {
+    enabled = "${var.versioning_enabled}"
+  }
+
+  lifecycle_rule {
+    id      = "${module.default_label.id}"
+    enabled = "${var.lifecycle_rule_enabled}"
+
+    prefix = "${var.prefix}"
+    tags   = "${module.default_label.tags}"
+
+    noncurrent_version_expiration {
+      days = "${var.noncurrent_version_expiration_days}"
+    }
+
+    noncurrent_version_transition {
+      days          = "${var.noncurrent_version_transition_days}"
+      storage_class = "GLACIER"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "default" {
+  bucket = "${aws_s3_bucket.default.id}"
+  policy = "${data.aws_iam_policy_document.default.json}"
+}
+
+data "aws_iam_policy_document" "default" {
+  statement {
+    actions = ["s3:GetObject"]
+
+    resources = ["${aws_s3_bucket.default.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+
+module "dns" {
+  source          = "git::https://github.com/cloudposse/tf_vanity?ref=tags/0.2.0"
+  aliases         = "${var.dns_zone_id ? list(var.hostname) : list()}"
+  zone_id         = "${var.dns_zone_id}"
+  target_dns_name = "${aws_s3_bucket.default.bucket_domain_name}"
+  target_zone_id  = "${aws_s3_bucket.default.hosted_zone_id}"
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,11 @@
+output "s3_bucket_name" {
+  value = "${aws_s3_bucket.default.id}"
+}
+
+output "s3_bucket_bucket_domain_name" {
+  value = "${aws_s3_bucket.default.bucket_domain_name}"
+}
+
+output "hostname" {
+  value = "${var.hostname}"
+}

--- a/output.tf
+++ b/output.tf
@@ -2,7 +2,7 @@ output "s3_bucket_name" {
   value = "${aws_s3_bucket.default.id}"
 }
 
-output "s3_bucket_bucket_domain_name" {
+output "s3_bucket_domain_name" {
   value = "${aws_s3_bucket.default.bucket_domain_name}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,42 @@
+variable "name" {}
+
+variable "namespage" {}
+
+variable "stage" {}
+
+variable "tags" {
+  default = {}
+}
+
+variable "dns_zone_id" {
+  description = "(optional) DNS zone to register DNS. Leave blank to disable DNS registration."
+  default     = ""
+}
+
+variable "index_document" {
+  default = "index.html"
+}
+
+variable "cors_allowed_headers" {
+  type    = "list"
+  default = ["*"]
+}
+
+variable "cors_allowed_methods" {
+  type    = "list"
+  default = ["GET"]
+}
+
+variable "cors_allowed_origins" {
+  type    = "list"
+  default = []
+}
+
+variable "cors_expose_headers" {
+  type    = "list"
+  default = ["ETag"]
+}
+
+variable "cors_max_age_seconds" {
+  default = "3600"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,18 @@
 variable "name" {}
 
-variable "namespage" {}
+variable "namespace" {}
 
 variable "stage" {}
 
 variable "tags" {
   default = {}
 }
+
+variable "delimiter" {
+  default = "-"
+}
+
+variable "hostname" {}
 
 variable "dns_zone_id" {
   description = "(optional) DNS zone to register DNS. Leave blank to disable DNS registration."
@@ -39,4 +45,51 @@ variable "cors_expose_headers" {
 
 variable "cors_max_age_seconds" {
   default = "3600"
+}
+
+variable "logs_standard_transition_days" {
+  description = "Number of days to persist in the standard storage tier before moving to the glacier tier"
+  default     = "30"
+}
+
+variable "logs_glacier_transition_days" {
+  description = "Number of days after which to move the data to the glacier storage tier"
+  default     = "60"
+}
+
+variable "logs_expiration_days" {
+  description = "Number of days after which to expunge the objects"
+  default     = "90"
+}
+
+variable "error_document" {
+  default = "404.html"
+}
+
+variable "lifecycle_rule_enabled" {
+  default = ""
+}
+
+variable "prefix" {
+  default = ""
+}
+
+variable "noncurrent_version_transition_days" {
+  default = "30"
+}
+
+variable "noncurrent_version_expiration_days" {
+  default = "90"
+}
+
+variable "region" {
+  default = ""
+}
+
+variable "versioning_enabled" {
+  default = ""
+}
+
+variable "force_destroy" {
+  default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,14 @@ variable "index_document" {
   default = "index.html"
 }
 
+variable "error_document" {
+  default = "404.html"
+}
+
+variable "routing_rules" {
+  default = ""
+}
+
 variable "cors_allowed_headers" {
   type    = "list"
   default = ["*"]
@@ -60,10 +68,6 @@ variable "logs_glacier_transition_days" {
 variable "logs_expiration_days" {
   description = "Number of days after which to expunge the objects"
   default     = "90"
-}
-
-variable "error_document" {
-  default = "404.html"
 }
 
 variable "lifecycle_rule_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,11 +12,11 @@ variable "delimiter" {
   default = "-"
 }
 
-variable "hostname" {}
+variable "hostname" {
+}
 
 variable "dns_zone_id" {
-  description = "(optional) DNS zone to register DNS. Leave blank to disable DNS registration."
-  default     = ""
+  description = "ID of the hosted zone to contain the record"
 }
 
 variable "index_document" {
@@ -43,7 +43,7 @@ variable "cors_allowed_methods" {
 
 variable "cors_allowed_origins" {
   type    = "list"
-  default = []
+  default = ["*"]
 }
 
 variable "cors_expose_headers" {


### PR DESCRIPTION
## what
* Create S3 bucket
* Enable versioning
* Support log storage to S3 bucket
* Support `A` record `ALIAS` to bucket name
* Support CORS
* Support Bucket Redirects
* Support routing rules

## why
* Efficient & Affordable hosting of static sites on S3
* Use as upstream for CloudFront distributions that require more advanced configurations